### PR TITLE
Updated styling for the config options

### DIFF
--- a/src/components/Item.js
+++ b/src/components/Item.js
@@ -1,25 +1,21 @@
-import React from 'react';
-import PropTypes from 'prop-types';
+import React from "react";
+import PropTypes from "prop-types";
 
-const stylesNormal = {overflow: 'visible'};
-const stylesLarge = {overflow: 'visible', height: 'auto'};
+const stylesNormal = { overflow: "visible" };
+const stylesLarge = { overflow: "visible", height: "auto" };
 
-function Item ({title, description, children, disabled, large}) {
-  const isDisabled = disabled ? 'disabled' : '';
+function Item({ title, description, children, disabled, large }) {
+  const isDisabled = disabled ? "disabled" : "";
   return (
     <li
       className={`mdl-list__item mdl-list__item--two-line ${isDisabled}`}
       style={large ? stylesLarge : stylesNormal}
-      >
-      <span className='mdl-list__item-primary-content'>
+    >
+      <span className="mdl-list__item-primary-content">
         <span>{title}</span>
-        <span className='mdl-list__item-sub-title'>
-          {description}
-        </span>
+        <span className="mdl-list__item-sub-title">{description}</span>
       </span>
-      <span className='mdl-list__item-secondary-content'>
-        {children}
-      </span>
+      <span className="mdl-list__item-secondary-content">{children}</span>
     </li>
   );
 }
@@ -27,7 +23,8 @@ function Item ({title, description, children, disabled, large}) {
 Item.propTypes = {
   title: PropTypes.string.isRequired,
   description: PropTypes.string,
-  children: PropTypes.oneOfType([PropTypes.element, PropTypes.array]).isRequired,
+  children: PropTypes.oneOfType([PropTypes.element, PropTypes.array])
+    .isRequired,
   disabled: PropTypes.bool,
   large: PropTypes.bool
 };

--- a/src/components/Presets/Presets.js
+++ b/src/components/Presets/Presets.js
@@ -1,29 +1,28 @@
-import React, { PureComponent } from 'react';
-import PropTypes from 'prop-types';
+import React, { PureComponent } from "react";
+import PropTypes from "prop-types";
 
-import './Presets.css';
+import "./Presets.css";
 
-import Select from '../controls/Select';
-import Item from '../Item';
+import Select from "../controls/Select";
+import Item from "../Item";
 
-import mining from './mining.json';
-import ports from './ports.json';
+import mining from "./mining.json";
+import ports from "./ports.json";
 
-import {mix, clone} from '../../util';
+import { mix, clone } from "../../util";
 
-function toVal (val) {
+function toVal(val) {
   return { name: val, value: val };
 }
 
 const presets = {
-  'None': null,
-  'Defaults': null,
-  'Mining': mining,
-  'Non-standard Ports': ports
+  None: null,
+  Defaults: null,
+  Mining: mining,
+  "Non-standard Ports": ports
 };
 
 class Presets extends PureComponent {
-
   static propTypes = {
     preset: PropTypes.string,
     defaults: PropTypes.object.isRequired,
@@ -31,16 +30,16 @@ class Presets extends PureComponent {
   };
 
   static defaultProps = {
-    preset: 'None'
+    preset: "None"
   };
 
-  change = (preset) => {
-    if (preset === 'None') {
+  change = preset => {
+    if (preset === "None") {
       return;
     }
 
-    if (this.props.preset === 'None') {
-      if (!window.confirm('Do you want to overwrite current config?')) {
+    if (this.props.preset === "None") {
+      if (!window.confirm("Do you want to overwrite current config?")) {
         this.forceUpdate();
         return;
       }
@@ -50,19 +49,19 @@ class Presets extends PureComponent {
     this.props.onChange(preset, data);
   };
 
-  render () {
-    const {preset} = this.props;
+  render() {
+    const { preset } = this.props;
 
     return (
-      <div className='presets'>
-        <Item title={''} description={'Load predefined config.'}>
+      <div className="presets">
+        <Item title={""} description={"Load predefined config."}>
           <Select
             onChange={this.change}
             value={preset}
             values={Object.keys(presets).map(toVal)}
-            id={'presets'}
+            id={"presets"}
             disabled={false}
-            />
+          />
         </Item>
       </div>
     );

--- a/src/components/Section.css
+++ b/src/components/Section.css
@@ -1,3 +1,8 @@
+.section-container {
+  height: 60vh;
+  overflow: scroll;
+  padding: 0 10px 20px 0;
+}
 .section {
   border-bottom: 2px solid #eee;
 }
@@ -23,4 +28,11 @@ h5.section {
 p.section {
   font-size: 12px;
   line-height: 18px;
+}
+
+@media screen and (max-width: 760px) {
+  .section-container {
+    height: auto;
+    overflow: visible;
+  }
 }

--- a/src/components/Section.js
+++ b/src/components/Section.js
@@ -40,17 +40,20 @@ class Section extends Component {
   render() {
     const { title, description, children } = this.props;
     const { collapsed } = this.state;
+
     return (
       <div className="section">
         <div onClick={this.toggleCollapsed} className="section-title">
           <h5 style={{ cursor: "pointer" }}>{title}</h5>
-          <button className="mdl-button mdl-js-button mdl-button--icon">
-            {collapsed ? (
-              <i className="material-icons">expand_more</i>
-            ) : (
-              <i className="material-icons">expand_less</i>
-            )}
-          </button>
+          {children.length > 0 && (
+            <button className="mdl-button mdl-js-button mdl-button--icon">
+              {collapsed ? (
+                <i className="material-icons">expand_more</i>
+              ) : (
+                <i className="material-icons">expand_less</i>
+              )}
+            </button>
+          )}
         </div>
         <p>{description}</p>
         <ul

--- a/src/index.css
+++ b/src/index.css
@@ -51,3 +51,9 @@ body {
 .list-item {
   padding: 0;
 }
+
+@media screen and (max-width: 760px) {
+  .main-panels {
+    padding: 0;
+  }
+}

--- a/src/material.css
+++ b/src/material.css
@@ -7349,13 +7349,12 @@ fieldset[disabled] .mdl-checkbox .mdl-checkbox__ripple-container .mdl-ripple,
   font-family: "AvenirLTStd-Light", "Helvetica", "Arial", sans-serif;
   font-size: 16px;
   font-weight: 400;
-  line-height: 24px;
   letter-spacing: 0.04em;
   line-height: 1;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  min-height: 48px;
+  /*min-height: 48px;*/
   box-sizing: border-box;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
@@ -7445,10 +7444,11 @@ fieldset[disabled] .mdl-checkbox .mdl-checkbox__ripple-container .mdl-ripple,
 }
 
 .mdl-list__item--two-line {
-  height: 72px;
+  /*min-height: 72px;*/
+  margin-bottom: 16px;
 }
 .mdl-list__item--two-line .mdl-list__item-primary-content {
-  height: 36px;
+  /*height: 36px;*/
   line-height: 20px;
   display: block;
 }
@@ -7464,14 +7464,13 @@ fieldset[disabled] .mdl-checkbox .mdl-checkbox__ripple-container .mdl-ripple,
 .mdl-list__item--two-line
   .mdl-list__item-primary-content
   .mdl-list__item-secondary-content {
-  height: 36px;
+  /*height: 36px;*/
 }
 .mdl-list__item--two-line
   .mdl-list__item-primary-content
   .mdl-list__item-sub-title {
   font-size: 14px;
   font-weight: 400;
-  line-height: 24px;
   letter-spacing: 0;
   line-height: 18px;
   color: rgba(0, 0, 0, 0.54);
@@ -7501,13 +7500,22 @@ fieldset[disabled] .mdl-checkbox .mdl-checkbox__ripple-container .mdl-ripple,
 .mdl-list__item--three-line .mdl-list__item-text-body {
   font-size: 14px;
   font-weight: 400;
-  line-height: 24px;
   letter-spacing: 0;
   line-height: 18px;
   height: 52px;
   color: rgba(0, 0, 0, 0.54);
   display: block;
   padding: 0;
+}
+
+@media screen and (max-width: 760px) {
+  .mdl-list__item {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+  .mdl-list__item .mdl-list__item-secondary-content {
+    margin: 0;
+  }
 }
 
 /**


### PR DESCRIPTION
## Description of changes

- Cleaned up set heights of list items
- Updated responsive styling
- Added a check for children in the collapsable items. 
- Added container around config options 

## Motivation for changes

- Height issues were causing text to overlap - unreadable
- Wasn't very responsive - lot's of overlapping
- Some of the collapsable items did not have children, so the button was 'useless'. No longer renders button if there are no children
- The container keeps everything neat in the page and is scrollable (like the config card, just not on a card)
